### PR TITLE
Add  `nginx.image.credentials` to Helm values

### DIFF
--- a/helm/baza/templates/statefulset.yaml
+++ b/helm/baza/templates/statefulset.yaml
@@ -77,6 +77,10 @@ spec:
     {{- with .Values.statefulset.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.nginx.image.credentials }}
+      imagePullSecrets:
+        - name: {{ printf "%s.nginx.registry" (include "baza.fullname" .) | quote }}
+    {{- end }}
       containers:
         - name: baza
           image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag | quote }}

--- a/helm/baza/values.yaml
+++ b/helm/baza/values.yaml
@@ -119,6 +119,7 @@ nginx:
     repository: docker.io/nginx
     tag: stable-alpine
     pullPolicy: IfNotPresent
+    credentials: {}
 
   port: 8080
 


### PR DESCRIPTION
## Synopsis

We need to be able to use nginx image from a private repository.

## Solution

Add `nginx.image.credentials` to Helm values and wire it up in `statefulset.yaml`

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
