### PR TITLE
Fix typo in the chart template preventing usage of image credentials

### DIFF
--- a/helm/baza/templates/secret.registry.yaml
+++ b/helm/baza/templates/secret.registry.yaml
@@ -13,7 +13,7 @@ metadata:
   name: {{ printf "%s.%s.registry" (include "baza.fullname" $) $name | quote }}
   namespace: {{ $.Release.Namespace | quote }}
   labels:
-    helm.sh/chart: {{ include "backend.chart" $ | quote }}
+    helm.sh/chart: {{ include "baza.chart" $ | quote }}
     app.kubernetes.io/name: {{ include "baza.name" $ | quote }}
     app.kubernetes.io/instance: {{ $.Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}


### PR DESCRIPTION
## Synopsis

Typo in the template name prevents installing the chart when credentials are used.

## Solution

Use correct template name. 

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
